### PR TITLE
Add tests for Hypriot OS release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ sd-image: build
 
 shell: build
 	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-xu4 bash
+
+testshell: build
+	docker run -ti --privileged -v $(shell pwd)/builder:/builder -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-xu4 bash

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -1,0 +1,35 @@
+require 'serverspec'
+set :backend, :exec
+
+describe "Root filesystem" do
+  let(:rootfs_path) { return '/build' }
+
+  it "exists" do
+    rootfs_dir = file(rootfs_path)
+
+    expect(rootfs_dir).to exist
+  end
+
+  context "Hypriot OS Release in /etc/os-release" do
+    let(:stdout) { command("cat #{rootfs_path}/etc/os-release").stdout }
+
+    it "has a HYPRIOT_OS= entry" do
+      expect(stdout).to contain('^HYPRIOT_OS=')
+    end
+    it "has a HYPRIOT_TAG= entry" do
+      expect(stdout).to contain('^HYPRIOT_TAG=')
+    end
+    it "has a HYPRIOT_DEVICE= entry" do
+      expect(stdout).to contain('^HYPRIOT_DEVICE=')
+    end
+
+    it "is for architecure 'HYPRIOT_OS=\"HypriotOS/armhf\"'" do
+      expect(stdout).to contain('^HYPRIOT_OS="HypriotOS/armhf"$')
+    end
+
+    it "is for device 'HYPRIOT_DEVICE=\"ODROID XU4\"'" do
+      expect(stdout).to contain('^HYPRIOT_DEVICE="ODROID XU4"$')
+    end
+
+  end
+end


### PR DESCRIPTION
These tests running at the end of the image creation. We're testing the existance of some of the very last modifications, which is the entry HYPRIOT_DEVICE. If anything bad happens within chroot, these tests will fail for sure.
