### PR TITLE
Fixed build problems with .dockerinit and bootini.deb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN gem update --system && \
     gem install --no-document pry-byebug && \
     gem install --no-document bundler
 
-RUN touch /.dockerinit
-
 COPY builder/ /builder/
 
 # build sd card image

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN gem update --system && \
     gem install --no-document pry-byebug && \
     gem install --no-document bundler
 
+RUN touch /.dockerinit
+
 COPY builder/ /builder/
 
 # build sd card image

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 # This script should be run only inside of a Docker container
-if [ ! -f /.dockerinit ]; then
+if [ ! -f /.dockerenv ]; then
   echo "ERROR: script works only in a Docker container!"
   exit 1
 fi

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -45,7 +45,7 @@ apt-get install -y u-boot-tools initramfs-tools
 #-don't create /media/boot, then all files will be installed in /boot
 #mkdir -p /media/boot
 apt-get install -y initramfs-tools
-wget -q -O /tmp/bootini.deb http://deb.odroid.in/5422/pool/main/b/bootini/bootini_20151220-14_armhf.deb
+wget -q -O /tmp/bootini.deb http://deb.odroid.in/5422/pool/main/b/bootini/bootini_20160412-15_armhf.deb 
 wget -q -O /tmp/linux-image-3.10.92-67_20151123_armhf.deb http://deb.odroid.in/umiddelb/linux-image-3.10.92-67_20151123_armhf.deb
 dpkg -i /tmp/bootini.deb /tmp/linux-image-3.10.92-67_20151123_armhf.deb
 rm -f /tmp/bootini.deb /tmp/linux-image-3.10.92-67_20151123_armhf.deb


### PR DESCRIPTION
It seems like the `/.dockerinit` file has been removed from containers. I added a `touch` to the `Dockerfile` to ensure its existence, but if you'd prefer to rely on `/.dockerenv` (which appeared to still be created in the container) I can change that as well.

Also, the link for the `bootini.deb` had been updated by the maintainer. After this fixes, the image was built correctly, and is working fine.

Let me know if this PR is OK.
