### PR TITLE
Use image-builder base image to minimize httpredir problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,12 @@
-FROM debian:jessie
+FROM hypriot/image-builder:latest
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python-pip \
-    build-essential \
-    libguestfs-tools \
-    libncurses5-dev \
-    tree \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
     binfmt-support \
     qemu \
     qemu-user-static \
-    debootstrap \
-    kpartx \
-    lvm2 \
-    dosfstools \
-    zip \
-    unzip \
-    pigz \
-    awscli \
-    ruby \
-    ruby-dev \
-    shellcheck \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
-
-RUN gem update --system && \
-    gem install --no-document serverspec && \
-    gem install --no-document pry-byebug && \
-    gem install --no-document bundler
 
 COPY builder/ /builder/
 


### PR DESCRIPTION
Use our hypriot/image-builder base image introduced after lots of problems with the httpredir service of debian.
